### PR TITLE
Fix bug in MultiHeadAttention

### DIFF
--- a/parakeet_mlx/attention.py
+++ b/parakeet_mlx/attention.py
@@ -44,7 +44,7 @@ class MultiHeadAttention(nn.Module):
             k, v = cache.update_and_fetch_kv(k, v)
 
         o = mx.fast.scaled_dot_product_attention(q, k, v, scale=self.scale, mask=mask)
-        o = o.transpose(0, 2, 1, 3).reshape(batch, q_seq, self.n_feat)
+        o = o.transpose(0, 2, 1, 3).reshape(batch, q_seq, self.head_dim * self.n_head)
 
         return self.linear_out(o)
 


### PR DESCRIPTION
Hello,

I'm using modules in this package for re-implementing Sortformer into MLX (and hopefully make adapter between canary and sortformer). I ran into this bug with MultiHeadAttention when writing the TransformerEncoder layer because n_feat wasn't set. Not sure if I was supposed to do something else in initializing them but I changed the forwarding. 
